### PR TITLE
Fix automerge by removing unneccesary username check

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,4 @@ jobs:
       pull-requests: write
     steps:
       - name: Auto-merge PR
-
-        if: github.event.pull_request.user.login == 'app/devin-ai-integration'
         uses: KeisukeYamashita/auto-pull-request-merge@v1


### PR DESCRIPTION
The username check should not be neccesary, because PRs from forks does not run Github Actions by default. The target used in this action should only run for internal PRs, and only Devin is making internal PRs.